### PR TITLE
Fix broken link on table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of awesome web crawler,spider and resources in different languages.
 - [Python](#python)
 - [Java](#java)
 - [C#](#c)
-- [JavaScript](#javaScript)
+- [JavaScript](#javascript)
 - [PHP](#php)
 - [C++](#c-1)
 - [C](#c-2)


### PR DESCRIPTION
The hash link to JavaScript section was broken.