### PR TITLE
Add selenium to python category

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A collection of awesome web crawler,spider and resources in different languages.
 * [spidy](https://github.com/rivermont/spidy) - The simple, easy to use command line web crawler. 
 * [newspaper](https://github.com/codelucas/newspaper) - News, full-text, and article metadata extraction in Python 3
 * [aspider](https://github.com/howie6879/aspider) - An async web scraping micro-framework based on asyncio. 
+* [Selenium](https://github.com/SeleniumHQ/selenium) - A browser automation framework and ecosystem.
 
 ## Java
 * [ACHE Crawler](https://github.com/ViDA-NYU/ache) - An easy to use web crawler for domain-specific search.


### PR DESCRIPTION
Adding [selenium](https://github.com/SeleniumHQ/selenium) web crawler to python category.